### PR TITLE
Fix role middleware alias

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -31,10 +31,18 @@ class Kernel extends HttpKernel
         ],
     ];
 
-    protected $routeMiddleware = [
+    /**
+     * Middleware aliases available to the application.
+     *
+     * Laravel 12 uses the `$middlewareAliases` property instead of
+     * `$routeMiddleware` for registering route middleware. Using the
+     * old property causes the framework to be unaware of custom
+     * middleware and results in errors such as
+     * `Target class [rol] does not exist` when the alias is used.
+     */
+    protected $middlewareAliases = [
         'auth' => \App\Http\Middleware\Authenticate::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'rol' => \App\Http\Middleware\VerificarRol::class,
- 
     ];
 }


### PR DESCRIPTION
## Summary
- register `rol` middleware using `middlewareAliases` to work with Laravel 12

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ddae60448322bf389f8038f6c206